### PR TITLE
Minor edits

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -136,7 +136,7 @@
 @misc{acm,
     author = "SIGOPS",
     title = "i386 Interrupt Handling",
-    url = "http://www.acm.uiuc.edu/sigops/roll_your_own/i386/irq.html"
+    url = "https://www-s.acm.illinois.edu/sigops/2007/roll_your_own/i386/irq.html"
 }
 
 @misc{nasm:macros,

--- a/getting_to_c.md
+++ b/getting_to_c.md
@@ -3,7 +3,7 @@ This chapter will show you how to use C instead of assembly code as the programm
 language for the OS. Assembly is very good for interacting with the CPU and
 enables maximum control over every aspect of the code.  However, at least for
 the authors, C is a much more convenient language to use. Therefore, we would
-like to use C as much as possible and use assembly code only where it make sense.
+like to use C as much as possible and use assembly code only where it makes sense.
 
 ## Setting Up a Stack
 One prerequisite for using C is a stack, since all non-trivial C programs use

--- a/output.md
+++ b/output.md
@@ -392,9 +392,10 @@ Therefore we use the configuration value `0x03 = 00000011` (RTS = 1 and DTS =
 ### Writing Data to the Serial Port
 
 Writing data to the serial port is done via the data I/O port. However, before
-writing, the transmit FIFO queue has to be empty (all previous writes must have
-finished). The transmit FIFO queue is empty if bit 5 of the line status I/O
-port is equal to one.
+writing, the transmit FIFO queue has to be empty. The line status I/O register
+uses bit 6 to denote that all previous writes have been completed, but for us
+it is sufficient to simply know that the transmit FIFO queue is empty. This is
+the case if bit 5 of the line status I/O port is equal to one.
 
 Reading the contents of an I/O port is done via the `in` assembly code instruction.
 There is no way to use the `in` assembly code instruction from C, therefore it has
@@ -448,7 +449,7 @@ Writing to a serial port means spinning as long as the transmit FIFO queue
 isn't empty, and then writing the data to the data I/O port.
 
 ### Configuring Bochs
-To save the output from the first serial serial port the Bochs configuration
+To save the output from the first serial port the Bochs configuration
 file `bochsrc.txt` must be updated.
 The `com1` configuration instructs Bochs how to handle first
 serial port:


### PR DESCRIPTION
Fix bibliography link to the x86 IRQ page.

Fix a couple of typos.

Clarify usage of bit 6 versus bit 5 in LSR and why bit 5 is used in the example.