### PR TITLE
Use grub-pc-bin

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -19,7 +19,7 @@ Once Ubuntu is installed, either physical or virtual, the following packages
 should be installed using `apt-get`:
 
 ~~~ {.bash}
-    sudo apt-get install build-essential nasm xorriso grub-pc bochs bochs-sdl
+    sudo apt-get install build-essential nasm xorriso grub-pc-bin bochs bochs-sdl
 ~~~
 
 ### Programming Languages


### PR DESCRIPTION
`grub-pc` replaces the GRUB implementation used by the host OS, while `-bin` only installs the binaries