### PR TITLE
Minor grammar and syntax fixes in io C source

### DIFF
--- a/file_systems.md
+++ b/file_systems.md
@@ -67,7 +67,7 @@ than others).
 
 ## Further Reading
 
-- The ideas behind the Plan 9 operating systems is worth taking a look at:
+- The ideas behind the Plan 9 operating system are worth taking a look at:
   <http://plan9.bell-labs.com/plan9/index.html>
 - Wikipedia's page on inodes: <http://en.wikipedia.org/wiki/Inode> and the
   inode pointer structure:

--- a/interrupts.md
+++ b/interrupts.md
@@ -238,7 +238,7 @@ hardware to interrupts. The reasons for configuring the PIC are:
 - Set up the correct mode for the PIC.
 
 In the beginning there was only one PIC (PIC 1) and eight interrupts. As more
-hardware were added, 8 interrupts were too few. The solution
+hardware was added, 8 interrupts became insufficient. The solution
 chosen was to chain on another PIC (PIC 2) on the first PIC (see interrupt 2 on
 PIC 1).
 

--- a/output.md
+++ b/output.md
@@ -247,7 +247,7 @@ line command port. An example is shown below:
 
     /* The I/O ports */
 
-    /* All the I/O ports are calculated relative to the data port. This is because
+    /* All I/O ports are calculated relative to the data port. This is because
      * all serial ports (COM1, COM2, COM3, COM4) have their ports in the same
      * order, but they start at different values.
      */

--- a/output.md
+++ b/output.md
@@ -243,7 +243,7 @@ highest 8 bits, then the lowest 8 bits. This is done by sending `0x80` to the
 line command port. An example is shown below:
 
 ~~~ {.c}
-    #include "io.h" /* io.h is implement in the section "Moving the cursor" */
+    #include "io.h" /* io.h is implemented in the section "Moving the cursor" */
 
     /* The I/O ports */
 

--- a/output.md
+++ b/output.md
@@ -95,7 +95,7 @@ The following code shows how this can be wrapped into a function:
     void fb_write_cell(unsigned int i, char c, unsigned char fg, unsigned char bg)
     {
         fb[i] = c;
-        fb[i + 1] = ((bg & 0x0F) << 4) | (fg & 0x0F)
+        fb[i + 1] = ((bg & 0x0F) << 4) | (fg & 0x0F);
     }
 ~~~
 

--- a/segmentation.md
+++ b/segmentation.md
@@ -33,7 +33,7 @@ the segment to use. The processor has six 16-bit segment registers: `cs`, `ss`,
 specifies the segment to use when fetching instructions. The register `ss` is
 used whenever accessing the stack (through the stack pointer `esp`), and `ds`
 is used for other data accesses. The OS is free to use the registers `es`, `gs`
-and `fs` however it want.
+and `fs` however it wants.
 
 Below is an example showing implicit use of the segment registers:
 

--- a/segmentation.md
+++ b/segmentation.md
@@ -85,7 +85,7 @@ writing data (Type is Read/Write) to put in the other segment registers.
 The DPL specifies the _privilege levels_ required to use the segment. x86
 allows for four privilege levels (PL), 0 to 3, where PL0 is the most
 privileged. In most operating systems (eg. Linux and Windows), only PL0 and PL3
-are used. However, some operating system, such as MINIX, make use of all
+are used. However, some operating systems, such as MINIX, make use of all
 levels. The kernel should be able to do anything, therefore it uses segments
 with DPL set to 0 (also called kernel mode). The current privilege level (CPL)
 is determined by the segment selector in `cs`.


### PR DESCRIPTION
C code comment should be `/* io.h is implemented ...`, not `/* io.h is implement ...`.

Removed unnecessary "the" from io C code comment.

Added missing semi-colon in `fb_write_cell` function.

Added and removed 's' to words that should, or should not, be plural.