### PR TITLE
Added `mtools` to dev dependency

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -19,7 +19,7 @@ Once Ubuntu is installed, either physical or virtual, the following packages
 should be installed using `apt-get`:
 
 ~~~ {.bash}
-    sudo apt-get install build-essential nasm xorriso grub-pc-bin bochs bochs-sdl
+    sudo apt-get install build-essential nasm xorriso grub-pc-bin bochs bochs-sdl mtools
 ~~~
 
 ### Programming Languages


### PR DESCRIPTION
Hey! Thanks for updating the book - I'm going along now too, so hopefully I can help resolve what will/won't work on my end.

`grub-mkrescue` depends on `mtools` to run the iso command, otherwise it will show an error: 'mformat' invocation failed.